### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Open a terminal, clone the repository, update the dependencies and build the pac
     $ cd ~/ros2_ws/src/ #use your current ros2 workspace folder
     $ git clone https://github.com/stereolabs/zed-ros2-examples.git
     $ cd ../
+    $ apt update
     $ rosdep install --from-paths src --ignore-src -r -y
     $ colcon build --symlink-install --cmake-args=-DCMAKE_BUILD_TYPE=Release
     $ source ~/.bashrc

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Open a terminal, clone the repository, update the dependencies and build the pac
     $ cd ../
     $ apt update
     $ rosdep install --from-paths src --ignore-src -r -y
+    $ source /opt/ros/humble/setup.sh
     $ colcon build --symlink-install --cmake-args=-DCMAKE_BUILD_TYPE=Release
     $ source ~/.bashrc
 


### PR DESCRIPTION
apt update is added before rosdep install
(I'm using the  Docker hub stereolabs/zedbot:zed-ros2-wrapper_u22_cuda117_humble_ image without any modification)