### PR TITLE
fix compile error

### DIFF
--- a/examples/zed_aruco_localization/CMakeLists.txt
+++ b/examples/zed_aruco_localization/CMakeLists.txt
@@ -179,7 +179,7 @@ if( ${FOUND_ROS2_DISTRO} STREQUAL "humble" OR ${FOUND_ROS2_DISTRO} STREQUAL "iro
     # Install header files
     install(
         DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/include/
-        DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/component/include/
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/component/include/
         DESTINATION include/${PROJECT_NAME}/
     )
 


### PR DESCRIPTION
fix compile error: https://community.stereolabs.com/t/build-error-for-zed-ros2-examples-in-zed-aruco-localization/7001/14
```sh
colcon build
```

origin version works only using `--symlink-install`.
```sh
colcon build --symlink-install
```
